### PR TITLE
Don't sort the years ascending.

### DIFF
--- a/ding_periodical.field.inc
+++ b/ding_periodical.field.inc
@@ -72,13 +72,6 @@ function ding_periodical_field_formatter_view($entity_type, $entity, $field, $in
     $availability = ding_provider_invoke('availability', 'holdings', array($entity->provider_id));
     if (isset($availability[$entity->provider_id])) {
       $issues = $availability[$entity->provider_id]['issues'];
-      // array_walk($issues, 'asort') complains about 'Notice: A non
-      // well formed numeric value encountered'.
-       foreach ($issues as $k => $v) {
-        asort($v);
-      }
-      ksort($issues);
-
       if ($issues) {
         $element[$delta] = array(
           '#theme' => 'ding_periodical_issues',


### PR DESCRIPTION
It makes more sense to have the newest years first instead of having the user scroll down the page to find the newest.
Also, it avoids wasting time on unnecessary sorting.